### PR TITLE
Make gtk_window_set_interactive_debugging take a window

### DIFF
--- a/lib/Gnome/Gtk3/Window.rakumod
+++ b/lib/Gnome/Gtk3/Window.rakumod
@@ -2557,7 +2557,7 @@ method set-interactive-debugging ( Bool $enable ) {
 }
 
 sub gtk_window_set_interactive_debugging (
-  gboolean $enable
+  N-GObject $window, gboolean $enable
 ) is native(&gtk-lib)
   { * }
 

--- a/xt/examples/b-in-w.raku
+++ b/xt/examples/b-in-w.raku
@@ -11,7 +11,7 @@ my Gnome::Gtk3::Button $b .= new(:label('The Button'));
 $w.add($b);
 $w.show-all;
 
-$w.set-interactive-debugging(1);
+$w.set-interactive-debugging(True);
 
 my Gnome::Gtk3::Main $m .= new;
 $m.gtk-main;


### PR DESCRIPTION
also changes the example that uses it to pass the right type, as it specifically asks for a boolean in its signature